### PR TITLE
Fix skip function

### DIFF
--- a/player/mpd/controller.js
+++ b/player/mpd/controller.js
@@ -385,6 +385,11 @@ function playerController() {
 		self.do_command_list([["seek", player.status.song, parseInt(seekto.toString())]]);
 	}
 
+	this.seekcur = function(seekto) {
+		debug.log("PLAYER","Seeking Current To",seekto);
+		self.do_command_list([["seekcur", seekto.toString()]]);
+	}
+
 	this.playId = function(id) {
 		playlist.checkPodcastProgress();
 		self.do_command_list([["playid",id]]);

--- a/player/player.js
+++ b/player/player.js
@@ -200,10 +200,7 @@ var player = function() {
 
 		skip: function(sec) {
 			if (this.status.state == "play") {
-				var p = player.status.progress ? 0 : player.status.progress;
-				var to = p + sec;
-				if (p < 0) p = 0;
-				this.controller.seek(to);
+				this.controller.seekcur(sec > 0 ? "+"+sec : sec);
 			}
 		}
 


### PR DESCRIPTION
More info:

https://www.musicpd.org/doc/html/protocol.html#controlling-playback

seekcur {TIME}
Seeks to the position TIME (in seconds; fractions allowed) within the current song. If prefixed by + or -, then the time is relative to the current playing position.

Tested with: Music Player Daemon 0.21.22 (0.21.22)

The old function produced exceptions in MPD:
forward skip: exception: Float expected:
backward skip: exception: Negative value not allowed: -10