### PR TITLE
double UFT-8 encoding fix

### DIFF
--- a/api/yourradio/index.php
+++ b/api/yourradio/index.php
@@ -52,7 +52,7 @@ function do_radio_list() {
 			'AlbumUri' => null,
 			'Year' => null,
 			'Artistname' => null,
-			'Albumname' => utf8_encode($playlist['StationName']),
+			'Albumname' => $playlist['StationName'],
 			'why' => 'whynot',
 			'ImgKey' => $albumimage->get_image_key(),
 			'streamuri' => $playlist['PlaylistUrl'],


### PR DESCRIPTION
Just a little issue ... saved radio station titles are broken if non-ascii characters are used due to unnecessary latin1->UTF conversion.