### PR TITLE
MPD Albumart stuff

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,4 +1,4 @@
-# Contribution Guiidelines
+# Contribution Guidelines
 
 The code for RompR is a toy to be played with.
 So it changes, frequently and unpredictably according to the whims

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,3 +3,4 @@ title: RompЯ
 description: A beautiful, feature-rich music player.
 show_downloads: false
 logo: https://raw.githubusercontent.com/fatg3erman/files/master/images/favicon-196.png
+include: Contributing.md

--- a/player/base_mpd_player.class.php
+++ b/player/base_mpd_player.class.php
@@ -256,9 +256,16 @@ class base_mpd_player {
 							}
 						}
 						if ($var[0] == 'binary') {
-							logger::log('MPDPLAYER', 'Reading',$retarr['binary'],'bytes of data');
-							$retarr['binarydata'] = fread($this->connection, $retarr['binary']);
-							fgets($this->connection);
+							$toread = $retarr['binary'];
+							logger::log('MPDPLAYER', 'Reading', $toread, 'bytes of binary data');
+							while ($toread > 0) {
+								$data = fread($this->connection, $toread);
+								$datalen = strlen($data);
+								$toread -= $datalen;
+								logger::trace('MPDPLAYER', 'Read', $datalen, 'bytes,', $toread, 'bytes more to go.');
+								$retarr['binarydata'] .= $data;
+							}
+							fgets($this->connection); // for the trailing newline
 						}
 					}
 				}
@@ -772,8 +779,9 @@ class base_mpd_player {
 		$filename = '';
 		$retries = 3;
 		logger::log('READPICTURE', 'Reading image from file',$uri);
-		// This doesn't fucking work because MPD is fucking shit fucker fuck fuck
-		// $this->do_mpd_command('binarylimit 32768');
+		if ($this->check_mpd_version('0.22.4')) {
+			$this->do_mpd_command('binarylimit 1048576');
+		}
 		while (($size === null || $size > 0) && $retries > 0) {
 			logger::log('MPDPLAYER', '  Reading at offset',$offset);
 			$result = $this->do_mpd_command('readpicture "'.$uri.'" '.$offset, true);
@@ -784,10 +792,15 @@ class base_mpd_player {
 					$filename = 'prefs/temp/'.md5($uri);
 					$handle = fopen($filename, 'w');
 				}
-				fwrite($handle, $result['binarydata']);
-				$size -= $result['binary'];
-				$offset += $result['binary'];
-				logger::log('MPDPLAYER', '    Remaining',$size);
+				if ($result['binary'] == strlen($result['binarydata'])) {
+					fwrite($handle, $result['binarydata']);
+					$size -= $result['binary'];
+					$offset += $result['binary'];
+					logger::log('MPDPLAYER', '    Remaining', $size);
+				} else {
+					logger::log('MPDPLAYER', '    Expected', $result['binary'], 'bytes but only got', strlen($result['binarydata']));
+					$retries--;
+				}
 			} else {
 				logger::log('READPICTURE', '    No binary data in response from MPD');
 				$retries--;

--- a/player/base_mpd_player.class.php
+++ b/player/base_mpd_player.class.php
@@ -772,23 +772,25 @@ class base_mpd_player {
 		return $retval;
 	}
 
-	public function readpicture($uri) {
+	public function albumart($uri, $embedded) {
 		$offset = 0;
 		$size = null;
 		$handle = null;
 		$filename = '';
 		$retries = 3;
-		logger::log('READPICTURE', 'Reading image from file',$uri);
+		logger::log('ALBUMART', 'Fetching', $embedded?'embedded':'folder', 'albumart for', $uri);
 		if ($this->check_mpd_version('0.22.4')) {
 			$this->do_mpd_command('binarylimit 1048576');
 		}
 		while (($size === null || $size > 0) && $retries > 0) {
 			logger::log('MPDPLAYER', '  Reading at offset',$offset);
-			$result = $this->do_mpd_command('readpicture "'.$uri.'" '.$offset, true);
+			$command = $embedded ? 'readpicture' : 'albumart';
+			$result = $this->do_mpd_command($command.' "'.$uri.'" '.$offset, true);
 			if (is_array($result) && array_key_exists('binary', $result)) {
 				if ($size === null) {
 					$size = $result['size'];
 					logger::log('MPDPLAYER', '    Size is',$size);
+					
 					$filename = 'prefs/temp/'.md5($uri);
 					$handle = fopen($filename, 'w');
 				}
@@ -802,7 +804,7 @@ class base_mpd_player {
 					$retries--;
 				}
 			} else {
-				logger::log('READPICTURE', '    No binary data in response from MPD');
+				logger::log('ALBUMART', '    No binary data in response from MPD');
 				$retries--;
 			}
 		}

--- a/utils/getalbumcover.php
+++ b/utils/getalbumcover.php
@@ -38,7 +38,7 @@ $player->probe_http_api();
 if (prefs::$prefs['mopidy_http_port'] !== false) {
 	array_unshift($searchfunctions, 'tryMopidy');
 }
-if ($player->check_mpd_version('0.22')) {
+if ($player->check_mpd_version('0.21')) {
 	array_unshift($searchfunctions, 'tryMPD');
 }
 
@@ -345,9 +345,17 @@ function tryMPD($albumimage) {
 		return '';
 
 	global $player;
-	logger::log('GETALBUMCOVER', 'Trying MPD Images. TrackURI is', $albumimage->trackuri);
 	$player->open_mpd_connection();
-	return $player->readpicture($albumimage->trackuri);
+	$filename = '';
+	if ($player->check_mpd_version('0.22')) {
+		logger::log('GETALBUMCOVER', 'Trying MPD embedded image. TrackURI is', $albumimage->trackuri);
+		$filename = $player->albumart($albumimage->trackuri, true);
+	}
+	if ($filename == '') {
+		logger::log('GETALBUMCOVER', 'Trying MPD folder image. TrackURI is', $albumimage->trackuri);
+		$filename = $player->albumart($albumimage->trackuri, false);
+	}
+	return $filename;
 }
 
 ?>


### PR DESCRIPTION
A recent update broke albumart for me: The images would load but only a small bit at the top was correct, the rest was gray/noise/missing. Dug into the code, found the issue, build and tested a bugfix. Then found some other stuff, fixed that too.

## Fix reading mpd binary responses
The `fread` call never returns more then ~16k bytes, at least on my system. Even `stream_set_read_buffer` does not fix that, so there must be some other buffer which limits the reads. To work around this, check the amount of data we got against what was requested. If we get less data then we requested, repeat the read until we got everything we want.

The [`binarylimit`](https://mpd.readthedocs.io/en/latest/protocol.html#connection-settings) command was added in mpd v0.22.4, so only use it when available. It is not necessary, it will just speed things up a bit.

## Add mpd albumart command support
Since v0.21 mpd has a [`albumart`](https://mpd.readthedocs.io/en/latest/protocol.html#the-music-database) command to fetch album art from the folder of the file. Embedded images still get priority.

## Fix contributing page
The [Contributing](https://fatg3erman.github.io/RompR/Contributing) page isn't working, but [it is there](https://fatg3erman.github.io/RompR/Contributing.md). Same issue as [this](https://stackoverflow.com/q/45899614/1094486), same solution as in [there](https://stackoverflow.com/a/45900131/1094486). And fixed a ty~~y~~po.