### PR TITLE
Adds missing properties in basealbumimage.class.php

### DIFF
--- a/util_classes/basealbumimage.class.php
+++ b/util_classes/basealbumimage.class.php
@@ -25,6 +25,11 @@ class baseAlbumImage {
 	public $albumuri;
 	public $trackuri;
 	public $dbimage;
+	public $baseimage;
+	public $image_downloaded;
+	public $basepath;
+	public $albumImage;
+	public $images;
 
 	public function __construct($params) {
 		foreach (array('artist', 'album', 'key', 'source', 'file', 'base64data', 'mbid', 'albumpath', 'albumuri', 'trackuri', 'dbimage') as $param) {


### PR DESCRIPTION
While adding a podcast, errors were raised complaining about undeclared properties, with this change the feed can be successfully added